### PR TITLE
Add Assistant AI functions

### DIFF
--- a/client-app/AIService.cs
+++ b/client-app/AIService.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -12,6 +13,7 @@ namespace client_app
     {
         private readonly HttpClient _httpClient;
         private AppConfiguration _config;
+        private string? currentThreadID;
 
         public AIService(HttpClient httpClient, AppConfiguration config)
         {
@@ -19,11 +21,11 @@ namespace client_app
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         }
 
-        public async Task<string?> GetAIResponseAsync(string prompt)
+        public async Task<string?> GetAICompletionResponseAsync(string prompt)
         {
             if (string.IsNullOrWhiteSpace(_config.ChatGPTApiKey) || string.IsNullOrWhiteSpace(_config.ChatGPTApiUrl))
             {
-                Debug.WriteLine($"Error communicating with ChatGPT API endpoint: API key or url not configured.");
+                Debug.WriteLine($"Error communicating with ChatGPT Completion API endpoint: API key or url not configured.");
 
                 return null;
             }
@@ -40,10 +42,11 @@ namespace client_app
 
             // To convert the JObject to a string if needed
             string requestString = requestObject.ToString();
+            string requestUri = $"{_config.ChatGPTApiUrl}/chat/completions";
 
-            Debug.WriteLine($"AI prompt / API Request payload: {requestString}");
+            Debug.WriteLine($"AI prompt Completion API request payload: {requestString}");
 
-            using (var requestMessage = new HttpRequestMessage(HttpMethod.Post, _config.ChatGPTApiUrl))
+            using (var requestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri))
             {
                 requestMessage.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _config.ChatGPTApiKey);
                 requestMessage.Content = new StringContent(requestString, Encoding.UTF8, "application/json");
@@ -67,10 +70,353 @@ namespace client_app
                 }
                 else
                 {
-                    Debug.WriteLine($"Error communicating with ChatGPT API endpoint at {_config.ChatGPTApiUrl}. Reason: {response.ReasonPhrase}");
+                    Debug.WriteLine($"Error communicating with ChatGPT API endpoint at {requestUri}. Reason: {response.ReasonPhrase}");
 
                     return $"Error: {response.ReasonPhrase}";
                 }
+            }
+        }
+
+        public async Task<string?> GetAIAssistantResponseAsync(string prompt)
+        {
+            if (string.IsNullOrWhiteSpace(_config.ChatGPTApiKey) || string.IsNullOrWhiteSpace(_config.ChatGPTApiUrl))
+            {
+                Debug.WriteLine($"Error communicating with ChatGPT Assistant API endpoint: API key or url not configured.");
+
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(currentThreadID) && !await CreateNewThread())
+            {
+                Debug.WriteLine($"Could not create a new thread for the Assistant API to use for prompt: {prompt}");
+
+                return null;
+            }
+
+            if (!await AddMessageToThread(prompt))
+            {
+                Debug.WriteLine($"Could not add a new message to thread for the Assistant API to use for prompt: {prompt}");
+
+                return null;
+            }
+
+            string? response = await RunCurrentAssistantAIThread_AndWaitForResponse();
+            if (string.IsNullOrWhiteSpace(response))
+            {
+                Debug.WriteLine($"Failed to get valid response from Assistant AI for prompt: {prompt}");
+
+                return null;
+            }
+
+            return response;
+        }
+
+        private async Task<string?> RetrieveAssistantAIGuid()
+        {
+            if (string.IsNullOrWhiteSpace(_config.ChatGPTApiKey) || string.IsNullOrWhiteSpace(_config.ChatGPTApiUrl))
+            {
+                Debug.WriteLine($"Error communicating with ChatGPT Retrieve Assistant ID API endpoint: API key or url not configured.");
+
+                return null;
+            }
+
+            string requestUri = $"{_config.ChatGPTApiUrl}/assistants";
+
+            Debug.WriteLine($"AI prompt Retrieve Assistant ID API request (no payload)");
+
+            using (var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri))
+            {
+                requestMessage.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _config.ChatGPTApiKey);
+                requestMessage.Headers.Add("OpenAI-Beta", "assistants=v2");
+
+                HttpResponseMessage response = await _httpClient.SendAsync(requestMessage);
+                if (response.IsSuccessStatusCode)
+                {
+                    string jsonResponse = await response.Content.ReadAsStringAsync();
+                    JObject responseObject = JObject.Parse(jsonResponse);
+
+                    string? assistantID = (string?)responseObject?["data"]?[0]?["id"];
+
+                    return assistantID;
+                }
+                else
+                {
+                    Debug.WriteLine($"Error communicating with ChatGPT Retrieve Assistant ID API endpoint at {requestUri}. Reason: {response.ReasonPhrase}");
+                }
+
+                return null;
+            }
+        }
+
+        private async Task<string?> RunCurrentAssistantAIThread()
+        {
+            if (string.IsNullOrWhiteSpace(currentThreadID))
+            {
+                Debug.WriteLine($"Current thread not set, and is unable to be run by the Assistant AI.");
+
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(_config.ChatGPTApiKey) || string.IsNullOrWhiteSpace(_config.ChatGPTApiUrl))
+            {
+                Debug.WriteLine($"Error communicating with ChatGPT Run Thread Assistant API endpoint: API key or url not configured.");
+
+                return null;
+            }
+
+            string? assistantID = _config.ChatGPTAssistantAI ?? await RetrieveAssistantAIGuid();
+            if (string.IsNullOrWhiteSpace(assistantID))
+            {
+                Debug.WriteLine($"Could not determine Assistant AI identifier to use, either from ENV or retrieved via API request.");
+
+                return null;
+            }
+
+            var requestObject = new JObject(
+                new JProperty("assistant_id", assistantID)
+            );
+
+            string requestString = requestObject.ToString();
+            string requestUri = $"{_config.ChatGPTApiUrl}/threads/{currentThreadID}/runs";
+
+            Debug.WriteLine($"AI prompt Run Thread Assistant API request (no payload)");
+
+            using (var requestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri))
+            {
+                requestMessage.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _config.ChatGPTApiKey);
+                requestMessage.Headers.Add("OpenAI-Beta", "assistants=v2");
+                requestMessage.Content = new StringContent(requestString, Encoding.UTF8, "application/json");
+
+                HttpResponseMessage response = await _httpClient.SendAsync(requestMessage);
+                if (response.IsSuccessStatusCode)
+                {
+                    string jsonResponse = await response.Content.ReadAsStringAsync();
+                    JObject responseObject = JObject.Parse(jsonResponse);
+
+                    return (string?)responseObject?["id"];
+                }
+                else
+                {
+                    Debug.WriteLine($"Error communicating with ChatGPT Run Thread Assistant API endpoint at {requestUri}. Reason: {response.ReasonPhrase}");
+                }
+
+                return null;
+            }
+        }
+
+        private async Task<string?> RunCurrentAssistantAIThread_AndWaitForResponse()
+        {
+            if (string.IsNullOrWhiteSpace(currentThreadID))
+            {
+                Debug.WriteLine($"Current thread not set, and required in order to wait for run response.");
+
+                return null;
+            }
+
+            string? runID = await RunCurrentAssistantAIThread();
+            if (string.IsNullOrWhiteSpace(runID))
+            {
+                Debug.WriteLine($"Failed to retrieve run ID from Run Thread Assistant API request.");
+
+                return null;
+            }
+
+            TimeSpan attemptInterval = TimeSpan.FromMilliseconds(_config.ChatGPTRetryInterval);
+            bool success = false;
+
+            for (int i = 0; i < _config.ChatGPTRetryMaxAttempts; i++)
+            {
+                if (await PollForAssistantAIRunCompletionState(runID) == "completed")
+                {
+                    success = true;
+                    break;
+                }
+
+                await Task.Delay(attemptInterval);
+            }
+
+            if (success)
+                return await GetLastMessageFromCurrentThread();
+
+            return null;
+        }
+
+        private async Task<string?> GetLastMessageFromCurrentThread()
+        {
+            if (string.IsNullOrWhiteSpace(currentThreadID))
+            {
+                Debug.WriteLine($"Failed to get last message from current thread- current thread not set.");
+
+                return null;
+            }
+
+            string requestUri = $"{_config.ChatGPTApiUrl}/threads/{currentThreadID}/messages";
+
+            Debug.WriteLine($"AI prompt Get Last Message Assistant API request (no payload)");
+
+            using (var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri))
+            {
+                requestMessage.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _config.ChatGPTApiKey);
+                requestMessage.Headers.Add("OpenAI-Beta", "assistants=v2");
+
+                HttpResponseMessage response = await _httpClient.SendAsync(requestMessage);
+                if (response.IsSuccessStatusCode)
+                {
+                    try
+                    {
+                        string jsonResponse = await response.Content.ReadAsStringAsync();
+                        JObject responseObject = JObject.Parse(jsonResponse);
+
+                        JArray? messageArray = (JArray?)responseObject["data"];
+                        JObject? lastMessage = (JObject?)messageArray?.FirstOrDefault();
+                        JObject? lastMessageContent = (JObject?)lastMessage?["content"]?.FirstOrDefault();
+                        string? lastMessageStr = (string?)lastMessageContent?["text"]?["value"];
+
+                        return lastMessageStr;
+                    }
+                    catch (Exception exc)
+                    {
+                        Debug.WriteLine($"An exception occurred parsing the last message in the current Assistant AI thread: {exc}");
+                    }
+
+                    return null;
+                }
+                else
+                {
+                    Debug.WriteLine($"Error communicating with ChatGPT Get Last Message Assistant API endpoint at {requestUri}. Reason: {response.ReasonPhrase}");
+                }
+
+                return null;
+            }
+        }
+
+        private async Task<string?> PollForAssistantAIRunCompletionState(string runID)
+        {
+            if (string.IsNullOrWhiteSpace(currentThreadID))
+            {
+                Debug.WriteLine($"Error communicating with ChatGPT Get Run State Assistant API endpoint: current thread ID not set.");
+
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(_config.ChatGPTApiKey) || string.IsNullOrWhiteSpace(_config.ChatGPTApiUrl))
+            {
+                Debug.WriteLine($"Error communicating with ChatGPT Get Run State Assistant API endpoint: API key or url not configured.");
+
+                return null;
+            }
+
+            string requestUri = $"{_config.ChatGPTApiUrl}/threads/{currentThreadID}/runs/{runID}";
+
+            Debug.WriteLine($"Polling for Assistant AI thread run completion...");
+
+            using (var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri))
+            {
+                requestMessage.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _config.ChatGPTApiKey);
+                requestMessage.Headers.Add("OpenAI-Beta", "assistants=v2");
+
+                HttpResponseMessage response = await _httpClient.SendAsync(requestMessage);
+                if (response.IsSuccessStatusCode)
+                {
+                    string jsonResponse = await response.Content.ReadAsStringAsync();
+                    JObject responseObject = JObject.Parse(jsonResponse);
+
+                    return (string?)responseObject?["status"];
+                }
+                else
+                {
+                    Debug.WriteLine($"Error communicating with ChatGPT Run Thread Assistant API endpoint at {requestUri}. Reason: {response.ReasonPhrase}");
+                }
+
+                return null;
+            }
+        }
+
+        private async Task<bool> AddMessageToThread(string message)
+        {
+            if (string.IsNullOrWhiteSpace(_config.ChatGPTApiKey) || string.IsNullOrWhiteSpace(_config.ChatGPTApiUrl))
+            {
+                Debug.WriteLine($"Error communicating with ChatGPT Add Message Assistant API endpoint: API key or url not configured.");
+
+                return false;
+            }
+
+            var requestObject = new JObject(
+                new JProperty("role", "user"),
+                new JProperty("content", message)
+            );
+
+            // To convert the JObject to a string if needed
+            string requestString = requestObject.ToString();
+            string requestUri = $"{_config.ChatGPTApiUrl}/threads/{currentThreadID}/messages";
+
+            Debug.WriteLine($"AI prompt Add Message Assistant API request payload: {requestString}");
+
+            using (var requestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri))
+            {
+                requestMessage.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _config.ChatGPTApiKey);
+                requestMessage.Headers.Add("OpenAI-Beta", "assistants=v2");
+                requestMessage.Content = new StringContent(requestString, Encoding.UTF8, "application/json");
+
+                HttpResponseMessage response = await _httpClient.SendAsync(requestMessage);
+                if (response.IsSuccessStatusCode)
+                {
+                    return true;
+                }
+                else
+                {
+                    Debug.WriteLine($"Error communicating with ChatGPT Add Message Assistant API endpoint at {requestUri}. Reason: {response.ReasonPhrase}");
+                }
+
+                return false;
+            }
+        }
+
+        private async Task<bool> CreateNewThread()
+        {
+            if (string.IsNullOrWhiteSpace(_config.ChatGPTApiKey) || string.IsNullOrWhiteSpace(_config.ChatGPTApiUrl))
+            {
+                Debug.WriteLine($"Error communicating with ChatGPT Create Thread Assistant API endpoint: API key or url not configured.");
+
+                return false;
+            }
+
+            string requestUri = $"{_config.ChatGPTApiUrl}/threads";
+
+            Debug.WriteLine($"AI prompt Create Thread Assistant API request (no payload)");
+
+            using (var requestMessage = new HttpRequestMessage(HttpMethod.Post, requestUri))
+            {
+                requestMessage.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _config.ChatGPTApiKey);
+                requestMessage.Headers.Add("OpenAI-Beta", "assistants=v2");
+                //requestMessage.Headers.Add("Content-Type", "application/json");
+                requestMessage.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+                HttpResponseMessage response = await _httpClient.SendAsync(requestMessage);
+                if (response.IsSuccessStatusCode)
+                {
+                    try
+                    {
+                        string jsonResponse = await response.Content.ReadAsStringAsync();
+                        JObject responseObject = JObject.Parse(jsonResponse);
+
+                        currentThreadID = (string?)responseObject["id"];
+
+                        return currentThreadID != null;
+                    }
+                    catch (Exception exc)
+                    {
+                        Debug.WriteLine($"An exception occurred parsing the Create Thread API response: {exc}");
+                    }
+
+                    return false;
+                }
+                else
+                {
+                    Debug.WriteLine($"Error communicating with ChatGPT Create Thread Assistant API endpoint at {_config.ChatGPTApiUrl}. Reason: {response.ReasonPhrase}");
+                }
+
+                return false;
             }
         }
     }

--- a/client-app/AppConfiguration.cs
+++ b/client-app/AppConfiguration.cs
@@ -18,5 +18,8 @@ namespace client_app
         public bool LoadLastProjectOnStartup { get; set; } = true;
         public string? ChatGPTApiKey { get; set; }
         public string? ChatGPTApiUrl { get; set; }
+        public string? ChatGPTAssistantAI { get; set; }
+        public int ChatGPTRetryMaxAttempts { get; set; } = 10;
+        public int ChatGPTRetryInterval { get; set; } = 100;
     }
 }

--- a/client-app/AppConfiguration.cs
+++ b/client-app/AppConfiguration.cs
@@ -19,7 +19,7 @@ namespace client_app
         public string? ChatGPTApiKey { get; set; }
         public string? ChatGPTApiUrl { get; set; }
         public string? ChatGPTAssistantAI { get; set; }
-        public int ChatGPTRetryMaxAttempts { get; set; } = 10;
-        public int ChatGPTRetryInterval { get; set; } = 100;
+        public int ChatGPTRetryMaxAttempts { get; set; } = 50;
+        public int ChatGPTRetryInterval { get; set; } = 200;
     }
 }

--- a/client-app/MainForm.AI.cs
+++ b/client-app/MainForm.AI.cs
@@ -17,6 +17,7 @@ namespace client_app
 
             bool messageAllowed = !string.IsNullOrWhiteSpace(_config?.ChatGPTApiKey) && !string.IsNullOrWhiteSpace(_config?.ChatGPTApiUrl);
             aiSendButton.Enabled = messageAllowed;
+            aiAssistantSendButton.Enabled = messageAllowed;
 
             if (!messageAllowed)
             {
@@ -33,7 +34,24 @@ namespace client_app
             string requestText = aiRequestTextbox.Text;
             if (!string.IsNullOrWhiteSpace(requestText))
             {
-                string? responseText = await _aiService.GetAIResponseAsync(requestText);
+                string? responseText = await _aiService.GetAICompletionResponseAsync(requestText);
+                aiResponseTextbox.Text = responseText;
+            }
+            else
+            {
+                MessageBox.Show("Please enter a request.");
+            }
+        }
+
+        private async void aiAssistantSendButton_Click(object sender, EventArgs e)
+        {
+            Debug.WriteLine($"Method: {nameof(aiAssistantSendButton_Click)}");
+            await Task.CompletedTask;
+
+            string requestText = aiRequestTextbox.Text;
+            if (!string.IsNullOrWhiteSpace(requestText))
+            {
+                string? responseText = await _aiService.GetAIAssistantResponseAsync(requestText);
                 aiResponseTextbox.Text = responseText;
             }
             else

--- a/client-app/MainForm.Designer.cs
+++ b/client-app/MainForm.Designer.cs
@@ -30,6 +30,7 @@ namespace client_app
         // ai
         private TabPage aiTab;
         private Button aiSendButton;
+        private Button aiAssistantSendButton;
         private TextBox aiRequestTextbox;
         private TextBox aiResponseTextbox;
         private Label aiResponseLabel;
@@ -80,6 +81,7 @@ namespace client_app
             tasksListBox = new ListBox();
             taskRemoveButton = new Button();
             taskCompleteButton = new Button();
+            aiAssistantSendButton = new Button();
             menuStrip.SuspendLayout();
             tabControl.SuspendLayout();
             projectTab.SuspendLayout();
@@ -212,6 +214,7 @@ namespace client_app
             aiTab.Controls.Add(aiRequestLabel);
             aiTab.Controls.Add(aiRequestTextbox);
             aiTab.Controls.Add(aiSendButton);
+            aiTab.Controls.Add(aiAssistantSendButton);
             aiTab.Location = new Point(4, 27);
             aiTab.Name = "aiTab";
             aiTab.Padding = new Padding(3);
@@ -228,6 +231,7 @@ namespace client_app
             aiResponseTextbox.Name = "aiResponseTextbox";
             aiResponseTextbox.PlaceholderText = "Please make a request.";
             aiResponseTextbox.ReadOnly = true;
+            aiResponseTextbox.ScrollBars = ScrollBars.Vertical;
             aiResponseTextbox.Size = new Size(539, 222);
             aiResponseTextbox.TabIndex = 3;
             // 
@@ -350,6 +354,17 @@ namespace client_app
             taskCompleteButton.Text = "Complete";
             taskCompleteButton.UseVisualStyleBackColor = true;
             taskCompleteButton.Click += taskCompleteButton_Click;
+            // 
+            // aiAssistantSendButton
+            // 
+            aiAssistantSendButton.BackColor = Color.FromArgb(192, 255, 192);
+            aiAssistantSendButton.Location = new Point(116, 133);
+            aiAssistantSendButton.Name = "aiAssistantSendButton";
+            aiAssistantSendButton.Size = new Size(200, 30);
+            aiAssistantSendButton.TabIndex = 5;
+            aiAssistantSendButton.Text = "Send (Assistant)";
+            aiAssistantSendButton.UseVisualStyleBackColor = false;
+            aiAssistantSendButton.Click += aiAssistantSendButton_Click;
             // 
             // MainForm
             // 

--- a/client-app/MainForm.Designer.cs
+++ b/client-app/MainForm.Designer.cs
@@ -63,10 +63,28 @@ namespace client_app
             recentProjects_MenuItem = new ToolStripMenuItem();
             tabControl = new TabControl();
             projectTab = new TabPage();
+            projectNameTextBox = new TextBox();
+            projectAuthorTextBox = new TextBox();
+            projectDescriptionTextBox = new TextBox();
+            projectSaveButton = new Button();
             aiTab = new TabPage();
+            aiResponseTextbox = new TextBox();
+            aiResponseLabel = new Label();
+            aiRequestLabel = new Label();
+            aiRequestTextbox = new TextBox();
+            aiSendButton = new Button();
             taskListTab = new TabPage();
+            taskTextBox = new TextBox();
+            taskAddButton = new Button();
+            taskEditButton = new Button();
+            tasksListBox = new ListBox();
+            taskRemoveButton = new Button();
+            taskCompleteButton = new Button();
             menuStrip.SuspendLayout();
             tabControl.SuspendLayout();
+            projectTab.SuspendLayout();
+            aiTab.SuspendLayout();
+            taskListTab.SuspendLayout();
             SuspendLayout();
             // 
             // menuStrip
@@ -74,7 +92,7 @@ namespace client_app
             menuStrip.Items.AddRange(new ToolStripItem[] { projectsMenu });
             menuStrip.Location = new Point(0, 0);
             menuStrip.Name = "menuStrip";
-            menuStrip.Size = new Size(366, 24);
+            menuStrip.Size = new Size(584, 24);
             menuStrip.TabIndex = 0;
             menuStrip.Text = "menuStrip";
             // 
@@ -82,157 +100,175 @@ namespace client_app
             // 
             projectsMenu.DropDownItems.AddRange(new ToolStripItem[] { createProject_MenuItem, editProject_MenuItem, loadProject_MenuItem, recentProjects_MenuItem });
             projectsMenu.Name = "projectsMenu";
+            projectsMenu.ShortcutKeyDisplayString = "P";
+            projectsMenu.ShortcutKeys = Keys.Alt | Keys.P;
             projectsMenu.Size = new Size(61, 20);
-            projectsMenu.Text = "Projects";
+            projectsMenu.Text = "&Projects";
             // 
             // createProject_MenuItem
             // 
             createProject_MenuItem.Name = "createProject_MenuItem";
-            createProject_MenuItem.Size = new Size(110, 22);
-            createProject_MenuItem.Text = "Create";
+            createProject_MenuItem.ShortcutKeyDisplayString = "C";
+            createProject_MenuItem.ShortcutKeys = Keys.Alt | Keys.C;
+            createProject_MenuItem.Size = new Size(180, 22);
+            createProject_MenuItem.Text = "&Create";
             createProject_MenuItem.Click += CreateProject_MenuItem_Click;
             // 
             // editProject_MenuItem
             // 
             editProject_MenuItem.Name = "editProject_MenuItem";
-            editProject_MenuItem.Size = new Size(110, 22);
-            editProject_MenuItem.Text = "Edit";
+            editProject_MenuItem.ShortcutKeyDisplayString = "E";
+            editProject_MenuItem.ShortcutKeys = Keys.Alt | Keys.E;
+            editProject_MenuItem.Size = new Size(180, 22);
+            editProject_MenuItem.Text = "&Edit";
             editProject_MenuItem.Click += EditProject_MenuItem_Click;
             // 
             // loadProject_MenuItem
             // 
             loadProject_MenuItem.Name = "loadProject_MenuItem";
-            loadProject_MenuItem.Size = new Size(110, 22);
-            loadProject_MenuItem.Text = "Load";
+            loadProject_MenuItem.ShortcutKeyDisplayString = "L";
+            loadProject_MenuItem.ShortcutKeys = Keys.Alt | Keys.L;
+            loadProject_MenuItem.Size = new Size(180, 22);
+            loadProject_MenuItem.Text = "&Load";
             loadProject_MenuItem.Click += LoadProject_MenuItem_Click;
             // 
             // recentProjects_MenuItem
             // 
             recentProjects_MenuItem.Name = "recentProjects_MenuItem";
-            recentProjects_MenuItem.Size = new Size(110, 22);
-            recentProjects_MenuItem.Text = "Recent";
-
-            InitializeProjectComponents();
-            InitializeAIComponents();
-            InitializeTaskListComponents();
-
+            recentProjects_MenuItem.ShortcutKeyDisplayString = "R";
+            recentProjects_MenuItem.ShortcutKeys = Keys.Alt | Keys.R;
+            recentProjects_MenuItem.Size = new Size(180, 22);
+            recentProjects_MenuItem.Text = "&Recent";
             // 
             // tabControl
             // 
             tabControl.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            tabControl.Appearance = TabAppearance.Buttons;
             tabControl.Controls.Add(projectTab);
             tabControl.Controls.Add(aiTab);
             tabControl.Controls.Add(taskListTab);
-            tabControl.Location = new Point(0, 27);
+            tabControl.Location = new Point(9, 24);
+            tabControl.Margin = new Padding(0);
             tabControl.Name = "tabControl";
+            tabControl.Padding = new Point(5, 3);
             tabControl.SelectedIndex = 0;
-            tabControl.Size = new Size(366, 392);
+            tabControl.Size = new Size(566, 428);
             tabControl.TabIndex = 0;
             tabControl.SelectedIndexChanged += TabControl_TabIndexChanged;
             // 
             // projectTab
             // 
-            projectTab.Location = new Point(4, 24);
-            projectTab.Name = "projectTab";
-            projectTab.Size = new Size(358, 364);
-            projectTab.TabIndex = 0;
-            // 
-            // aiTab
-            // 
-            aiTab.Location = new Point(4, 24);
-            aiTab.Name = "aiTab";
-            aiTab.Size = new Size(358, 394);
-            aiTab.TabIndex = 1;
-            // 
-            // taskListTab
-            // 
-            taskListTab.Location = new Point(4, 24);
-            taskListTab.Name = "taskListTab";
-            taskListTab.Size = new Size(358, 394);
-            taskListTab.TabIndex = 2;
-            // 
-            // MainForm
-            // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(366, 422);
-            Controls.Add(menuStrip);
-            Controls.Add(tabControl);
-            MainMenuStrip = menuStrip;
-            Name = "MainForm";
-            Text = "Helper App (No Project Loaded)";
-            Load += MainForm_Load;
-            menuStrip.ResumeLayout(false);
-            menuStrip.PerformLayout();
-            tabControl.ResumeLayout(false);
-            ResumeLayout(false);
-            PerformLayout();
-        }
-
-        private void InitializeProjectComponents()
-        {
-            _tabSelectedActions[projectTab] = OnProjectTabSelected;
-
-            projectNameTextBox = new TextBox();
-            projectAuthorTextBox = new TextBox();
-            projectDescriptionTextBox = new TextBox();
-            projectSaveButton = new Button();
-
-            // Project Tab
             projectTab.Controls.Add(projectNameTextBox);
             projectTab.Controls.Add(projectAuthorTextBox);
             projectTab.Controls.Add(projectDescriptionTextBox);
             projectTab.Controls.Add(projectSaveButton);
-            projectTab.Location = new System.Drawing.Point(4, 22);
+            projectTab.Location = new Point(4, 27);
             projectTab.Name = "projectTab";
             projectTab.Padding = new Padding(3);
-            projectTab.Size = new System.Drawing.Size(792, 424);
+            projectTab.Size = new Size(558, 397);
             projectTab.TabIndex = 2;
             projectTab.Text = "Project";
             projectTab.UseVisualStyleBackColor = true;
-
-            // Project Name TextBox
-            projectNameTextBox.Location = new System.Drawing.Point(20, 20);
+            // 
+            // projectNameTextBox
+            // 
+            projectNameTextBox.Location = new Point(8, 6);
             projectNameTextBox.Name = "projectNameTextBox";
-            projectNameTextBox.Size = new System.Drawing.Size(300, 20);
-            projectNameTextBox.TabIndex = 0;
             projectNameTextBox.PlaceholderText = "Project Name";
-
-            // Project Author TextBox
-            projectAuthorTextBox.Location = new System.Drawing.Point(20, 60);
+            projectNameTextBox.Size = new Size(544, 23);
+            projectNameTextBox.TabIndex = 0;
+            // 
+            // projectAuthorTextBox
+            // 
+            projectAuthorTextBox.Location = new Point(8, 35);
             projectAuthorTextBox.Name = "projectAuthorTextBox";
-            projectAuthorTextBox.Size = new System.Drawing.Size(300, 20);
-            projectAuthorTextBox.TabIndex = 1;
             projectAuthorTextBox.PlaceholderText = "Author";
-
-            // Project Description TextBox
-            projectDescriptionTextBox.Location = new System.Drawing.Point(20, 100);
+            projectAuthorTextBox.Size = new Size(544, 23);
+            projectAuthorTextBox.TabIndex = 1;
+            // 
+            // projectDescriptionTextBox
+            // 
+            projectDescriptionTextBox.Location = new Point(8, 64);
+            projectDescriptionTextBox.Multiline = true;
             projectDescriptionTextBox.Name = "projectDescriptionTextBox";
-            projectDescriptionTextBox.Size = new System.Drawing.Size(300, 20);
-            projectDescriptionTextBox.TabIndex = 2;
             projectDescriptionTextBox.PlaceholderText = "Description";
-
-            // Save Project Button
-            projectSaveButton.Location = new System.Drawing.Point(20, 140);
-            projectSaveButton.Name = "saveProjectButton";
-            projectSaveButton.Size = new System.Drawing.Size(75, 23);
+            projectDescriptionTextBox.Size = new Size(544, 70);
+            projectDescriptionTextBox.TabIndex = 2;
+            // 
+            // projectSaveButton
+            // 
+            projectSaveButton.Location = new Point(8, 140);
+            projectSaveButton.Name = "projectSaveButton";
+            projectSaveButton.Size = new Size(75, 23);
             projectSaveButton.TabIndex = 3;
             projectSaveButton.Text = "Save";
             projectSaveButton.UseVisualStyleBackColor = true;
-            projectSaveButton.Click += new EventHandler(SaveProject_Button_Click);
-        }
-
-        private void InitializeTaskListComponents()
-        {
-            _tabSelectedActions[taskListTab] = OnTaskListTabSelected;
-
-            taskTextBox = new TextBox();
-            taskAddButton = new Button();
-            taskEditButton = new Button();
-            tasksListBox = new ListBox();
-            taskRemoveButton = new Button();
-            taskCompleteButton = new Button();
-
+            projectSaveButton.Click += SaveProject_Button_Click;
+            // 
+            // aiTab
+            // 
+            aiTab.Controls.Add(aiResponseTextbox);
+            aiTab.Controls.Add(aiResponseLabel);
+            aiTab.Controls.Add(aiRequestLabel);
+            aiTab.Controls.Add(aiRequestTextbox);
+            aiTab.Controls.Add(aiSendButton);
+            aiTab.Location = new Point(4, 27);
+            aiTab.Name = "aiTab";
+            aiTab.Padding = new Padding(3);
+            aiTab.Size = new Size(558, 397);
+            aiTab.TabIndex = 1;
+            aiTab.Text = "Chat";
+            aiTab.UseVisualStyleBackColor = true;
+            // 
+            // aiResponseTextbox
+            // 
+            aiResponseTextbox.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            aiResponseTextbox.Location = new Point(11, 169);
+            aiResponseTextbox.Multiline = true;
+            aiResponseTextbox.Name = "aiResponseTextbox";
+            aiResponseTextbox.PlaceholderText = "Please make a request.";
+            aiResponseTextbox.ReadOnly = true;
+            aiResponseTextbox.Size = new Size(539, 222);
+            aiResponseTextbox.TabIndex = 3;
+            // 
+            // aiResponseLabel
+            // 
+            aiResponseLabel.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Right;
+            aiResponseLabel.AutoSize = true;
+            aiResponseLabel.Location = new Point(493, 148);
+            aiResponseLabel.Name = "aiResponseLabel";
+            aiResponseLabel.Size = new Size(57, 15);
+            aiResponseLabel.TabIndex = 2;
+            aiResponseLabel.Text = "Response";
+            // 
+            // aiRequestLabel
+            // 
+            aiRequestLabel.AutoSize = true;
+            aiRequestLabel.Location = new Point(6, 6);
+            aiRequestLabel.Name = "aiRequestLabel";
+            aiRequestLabel.Size = new Size(49, 15);
+            aiRequestLabel.TabIndex = 1;
+            aiRequestLabel.Text = "Request";
+            // 
+            // aiRequestTextbox
+            // 
+            aiRequestTextbox.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            aiRequestTextbox.Location = new Point(6, 24);
+            aiRequestTextbox.Multiline = true;
+            aiRequestTextbox.Name = "aiRequestTextbox";
+            aiRequestTextbox.Size = new Size(544, 106);
+            aiRequestTextbox.TabIndex = 0;
+            // 
+            // aiSendButton
+            // 
+            aiSendButton.BackColor = Color.FromArgb(192, 255, 192);
+            aiSendButton.Location = new Point(6, 133);
+            aiSendButton.Name = "aiSendButton";
+            aiSendButton.Size = new Size(100, 30);
+            aiSendButton.TabIndex = 4;
+            aiSendButton.Text = "Send";
+            aiSendButton.UseVisualStyleBackColor = false;
+            aiSendButton.Click += aiSendButton_Click;
             // 
             // taskListTab
             // 
@@ -242,10 +278,10 @@ namespace client_app
             taskListTab.Controls.Add(tasksListBox);
             taskListTab.Controls.Add(taskRemoveButton);
             taskListTab.Controls.Add(taskCompleteButton);
-            taskListTab.Location = new Point(4, 24);
+            taskListTab.Location = new Point(4, 27);
             taskListTab.Name = "taskListTab";
             taskListTab.Padding = new Padding(3);
-            taskListTab.Size = new Size(358, 394);
+            taskListTab.Size = new Size(558, 397);
             taskListTab.TabIndex = 0;
             taskListTab.Text = "Task List";
             taskListTab.UseVisualStyleBackColor = true;
@@ -253,28 +289,28 @@ namespace client_app
             // taskTextBox
             // 
             taskTextBox.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
-            taskTextBox.Location = new Point(7, 14);
+            taskTextBox.Location = new Point(6, 6);
             taskTextBox.Name = "taskTextBox";
-            taskTextBox.Size = new Size(263, 23);
+            taskTextBox.Size = new Size(468, 23);
             taskTextBox.TabIndex = 0;
             // 
-            // addButton
+            // taskAddButton
             // 
             taskAddButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             taskAddButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            taskAddButton.Location = new Point(280, 13);
-            taskAddButton.Name = "addButton";
+            taskAddButton.Location = new Point(480, 7);
+            taskAddButton.Name = "taskAddButton";
             taskAddButton.Size = new Size(72, 22);
             taskAddButton.TabIndex = 1;
             taskAddButton.Text = "Add";
             taskAddButton.UseVisualStyleBackColor = true;
             taskAddButton.Click += taskAddButton_Click;
             // 
-            // editButton
+            // taskEditButton
             // 
             taskEditButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
-            taskEditButton.Location = new Point(280, 41);
-            taskEditButton.Name = "editButton";
+            taskEditButton.Location = new Point(480, 35);
+            taskEditButton.Name = "taskEditButton";
             taskEditButton.Size = new Size(72, 23);
             taskEditButton.TabIndex = 5;
             taskEditButton.Text = "Edit";
@@ -286,111 +322,59 @@ namespace client_app
             tasksListBox.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
             tasksListBox.FormattingEnabled = true;
             tasksListBox.ItemHeight = 15;
-            tasksListBox.Location = new Point(7, 47);
+            tasksListBox.Location = new Point(6, 35);
             tasksListBox.Name = "tasksListBox";
-            tasksListBox.Size = new Size(263, 334);
+            tasksListBox.Size = new Size(468, 349);
             tasksListBox.TabIndex = 2;
             // 
-            // removeButton
+            // taskRemoveButton
             // 
             taskRemoveButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             taskRemoveButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            taskRemoveButton.Location = new Point(280, 70);
-            taskRemoveButton.Name = "removeButton";
+            taskRemoveButton.Location = new Point(480, 64);
+            taskRemoveButton.Name = "taskRemoveButton";
             taskRemoveButton.Size = new Size(72, 22);
             taskRemoveButton.TabIndex = 3;
             taskRemoveButton.Text = "Remove";
             taskRemoveButton.UseVisualStyleBackColor = true;
             taskRemoveButton.Click += taskRemoveButton_Click;
             // 
-            // completeButton
+            // taskCompleteButton
             // 
             taskCompleteButton.Anchor = AnchorStyles.Top | AnchorStyles.Right;
             taskCompleteButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            taskCompleteButton.Location = new Point(280, 98);
-            taskCompleteButton.Name = "completeButton";
+            taskCompleteButton.Location = new Point(480, 92);
+            taskCompleteButton.Name = "taskCompleteButton";
             taskCompleteButton.Size = new Size(72, 22);
             taskCompleteButton.TabIndex = 4;
             taskCompleteButton.Text = "Complete";
             taskCompleteButton.UseVisualStyleBackColor = true;
             taskCompleteButton.Click += taskCompleteButton_Click;
-        }
-
-        private void InitializeAIComponents()
-        {
-            _tabSelectedActions[aiTab] = OnAITabSelected;
-
-            aiResponseTextbox = new TextBox();
-            aiResponseLabel = new Label();
-            aiRequestLabel = new Label();
-            aiRequestTextbox = new TextBox();
-            aiSendButton = new Button();
-
             // 
-            // aiTab
+            // MainForm
             // 
-            aiTab.Controls.Add(aiResponseTextbox);
-            aiTab.Controls.Add(aiResponseLabel);
-            aiTab.Controls.Add(aiRequestLabel);
-            aiTab.Controls.Add(aiRequestTextbox);
-            aiTab.Controls.Add(aiSendButton);
-            aiTab.Location = new Point(4, 24);
-            aiTab.Name = "chatTab";
-            aiTab.Padding = new Padding(3);
-            aiTab.Size = new Size(358, 394);
-            aiTab.TabIndex = 1;
-            aiTab.Text = "Chat";
-            aiTab.UseVisualStyleBackColor = true;
-            // 
-            // responseTextbox
-            // 
-            aiResponseTextbox.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
-            aiResponseTextbox.Location = new Point(6, 169);
-            aiResponseTextbox.Multiline = true;
-            aiResponseTextbox.Name = "responseTextbox";
-            aiResponseTextbox.PlaceholderText = "Please make a request.";
-            aiResponseTextbox.ReadOnly = true;
-            aiResponseTextbox.Size = new Size(344, 217);
-            aiResponseTextbox.TabIndex = 3;
-            // 
-            // responseLabel
-            // 
-            aiResponseLabel.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Right;
-            aiResponseLabel.AutoSize = true;
-            aiResponseLabel.Location = new Point(293, 151);
-            aiResponseLabel.Name = "responseLabel";
-            aiResponseLabel.Size = new Size(57, 15);
-            aiResponseLabel.TabIndex = 2;
-            aiResponseLabel.Text = "Response";
-            // 
-            // requestLabel
-            // 
-            aiRequestLabel.AutoSize = true;
-            aiRequestLabel.Location = new Point(8, 3);
-            aiRequestLabel.Name = "requestLabel";
-            aiRequestLabel.Size = new Size(49, 15);
-            aiRequestLabel.TabIndex = 1;
-            aiRequestLabel.Text = "Request";
-            // 
-            // requestTextbox
-            // 
-            aiRequestTextbox.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
-            aiRequestTextbox.Location = new Point(6, 21);
-            aiRequestTextbox.Multiline = true;
-            aiRequestTextbox.Name = "requestTextbox";
-            aiRequestTextbox.Size = new Size(344, 106);
-            aiRequestTextbox.TabIndex = 0;
-            // 
-            // sendButton
-            // 
-            aiSendButton.BackColor = Color.FromArgb(192, 255, 192);
-            aiSendButton.Location = new Point(6, 133);
-            aiSendButton.Name = "sendButton";
-            aiSendButton.Size = new Size(100, 30);
-            aiSendButton.TabIndex = 4;
-            aiSendButton.Text = "Send";
-            aiSendButton.UseVisualStyleBackColor = false;
-            aiSendButton.Click += aiSendButton_Click;
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(584, 461);
+            Controls.Add(menuStrip);
+            Controls.Add(tabControl);
+            MainMenuStrip = menuStrip;
+            Name = "MainForm";
+            SizeGripStyle = SizeGripStyle.Hide;
+            StartPosition = FormStartPosition.CenterScreen;
+            Text = "Helper App (No Project Loaded)";
+            Load += MainForm_Load;
+            menuStrip.ResumeLayout(false);
+            menuStrip.PerformLayout();
+            tabControl.ResumeLayout(false);
+            projectTab.ResumeLayout(false);
+            projectTab.PerformLayout();
+            aiTab.ResumeLayout(false);
+            aiTab.PerformLayout();
+            taskListTab.ResumeLayout(false);
+            taskListTab.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
     }
 }

--- a/client-app/MainForm.Project.cs
+++ b/client-app/MainForm.Project.cs
@@ -111,12 +111,20 @@ namespace client_app
             Debug.WriteLine($"Method: {nameof(OnCurrentProjectChanged)}");
             await Task.CompletedTask;
 
-            if (tabControl.SelectedTab != projectTab)
-                tabControl.SelectTab(projectTab);
+            if (InvokeRequired)
+            {
+                // If the method is called from a different thread, invoke it on the UI thread
+                Invoke(new Action<ProjectData?>(OnCurrentProjectChanged), newProject);
+            }
             else
-                ReloadProjectData();
+            {
+                if (tabControl.SelectedTab != projectTab)
+                    tabControl.SelectTab(projectTab);
+                else
+                    ReloadProjectData();
 
-            PopulateRecentProjectsMenu();
+                PopulateRecentProjectsMenu();
+            }
         }
     }
 }

--- a/client-app/MainForm.cs
+++ b/client-app/MainForm.cs
@@ -20,6 +20,10 @@ namespace client_app
             _aiService = aiService ?? throw new ArgumentNullException(nameof(aiService));
 
             InitializeComponent();
+
+            _tabSelectedActions[projectTab] = OnProjectTabSelected;
+            _tabSelectedActions[taskListTab] = OnTaskListTabSelected;
+            _tabSelectedActions[aiTab] = OnAITabSelected;
         }
 
         private async void MainForm_Load(object sender, EventArgs e)

--- a/client-app/MainForm.resx
+++ b/client-app/MainForm.resx
@@ -120,4 +120,7 @@
   <metadata name="menuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="$this.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
 </root>


### PR DESCRIPTION
Adds the ability for the Assistant AI to execute "functions" on the client/application to get supplemental information to respond to queries. This is being leveraged a bit incorrectly at the moment, as I misunderstood the feature at first, and should be refactored so that any "action_requested" states will iterate through the list of tools being specified, and invoke actions from a lookup so that each is handled appropriately, with the right response given back and fed into the next request to the developer API endpoint.

Added a separate button on the AI tab for executing requests with the Assistant AI, so that the legacy/completion API can still be used while working out the kinks with the v2 APIs.

Consolidated all designer code back into the original InitializeComponent() method, because Visual Studio kept forcing whole blocks back to that method anyways- generated code conflicts with trying to organize things manually, so I'll try to leave the designer code alone from now on where possible.